### PR TITLE
Update implementations of Stream.{lastWhere, firstWhere} for Dart 2

### DIFF
--- a/lib/src/instances/stream_monad.dart
+++ b/lib/src/instances/stream_monad.dart
@@ -335,7 +335,7 @@ class StreamMonad<T> extends Monad<T> implements Stream<T> {
 
   @override
   FutureMonad<T> firstWhere(bool Function(T element) test,
-      {T Function() orElse}) =>
+          {T Function() orElse}) =>
       new FutureMonad(_stream.firstWhere(test, orElse: orElse));
 
   @override
@@ -437,7 +437,7 @@ class StreamMonad<T> extends Monad<T> implements Stream<T> {
 
   @override
   FutureMonad<T> lastWhere(bool Function(T element) test,
-      {T Function() orElse}) =>
+          {T Function() orElse}) =>
       new FutureMonad(_stream.lastWhere(test, orElse: orElse));
 
   @override

--- a/lib/src/instances/stream_monad.dart
+++ b/lib/src/instances/stream_monad.dart
@@ -334,9 +334,9 @@ class StreamMonad<T> extends Monad<T> implements Stream<T> {
       new StreamMonad(_stream.expand(convert));
 
   @override
-  FutureMonad<T> firstWhere(bool test(T element),
-          {Object defaultValue(), T orElse()}) =>
-      new FutureMonad(_stream.firstWhere(test, orElse: orElse ?? defaultValue));
+  FutureMonad<T> firstWhere(bool Function(T element) test,
+      {T Function() orElse}) =>
+      new FutureMonad(_stream.firstWhere(test, orElse: orElse));
 
   @override
   StreamMonad<S> flatMap<S>(Function1<T, StreamMonad<S>> f) {
@@ -436,9 +436,9 @@ class StreamMonad<T> extends Monad<T> implements Stream<T> {
       new FutureMonad(_stream.join(separator));
 
   @override
-  FutureMonad<T> lastWhere(bool test(T element),
-          {Object defaultValue(), T orElse()}) =>
-      new FutureMonad(_stream.lastWhere(test, orElse: orElse ?? defaultValue));
+  FutureMonad<T> lastWhere(bool Function(T element) test,
+      {T Function() orElse}) =>
+      new FutureMonad(_stream.lastWhere(test, orElse: orElse));
 
   @override
   StreamSubscription<T> listen(void onData(T event),


### PR DESCRIPTION
Fixes #42