### PR TITLE
Mark implementations of `retype` as not needing to override.

### DIFF
--- a/lib/src/instances/option.dart
+++ b/lib/src/instances/option.dart
@@ -39,6 +39,7 @@ class None<T> extends Option<T> with EmptyIterableMixin<T, Option<T>> {
   Option<S> map<S>(Function1<T, S> f) => new None<S>();
 
   @override
+  // ignore: override_on_non_overriding_method
   Iterable<T> retype<T>() {
     throw new UnimplementedError('retype');
   }
@@ -141,6 +142,7 @@ class Some<T> extends Option<T> with SingleValueIterableMixin<T, Option<T>> {
   Option<S> map<S>(Function1<T, S> f) => new Some<S>(f(value));
 
   @override
+  // ignore: override_on_non_overriding_method
   Iterable<T> retype<T>() {
     throw new UnimplementedError('retype');
   }

--- a/lib/src/instances/stream_monad.dart
+++ b/lib/src/instances/stream_monad.dart
@@ -518,6 +518,7 @@ class StreamMonad<T> extends Monad<T> implements Stream<T> {
 
   @override
   @Deprecated('Use cast instead.')
+  // ignore: override_on_non_overriding_method
   StreamMonad<R> retype<R>() => new StreamMonad<R>(_stream.cast<R>());
 
   /// Applies an accumulator function over the this stream, and returns each

--- a/lib/src/instances/try.dart
+++ b/lib/src/instances/try.dart
@@ -66,6 +66,7 @@ class Failure<T> extends Try<T> with EmptyIterableMixin<T, Try<T>> {
       onFailure(error);
 
   @override
+  // ignore: override_on_non_overriding_method
   Iterable<T> retype<T>() {
     throw new UnimplementedError('retype');
   }
@@ -139,6 +140,7 @@ class Success<T> extends Try<T> with SingleValueIterableMixin<T, Try<T>> {
   Try<T> recoverWith(Function1<Exception, Try<T>> onFailure) => this;
 
   @override
+  // ignore: override_on_non_overriding_method
   Iterable<T> retype<T>() {
     throw new UnimplementedError('retype');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shuttlecock
 description: An algebraic types library inspired by the course Category theory for programmers by Bartosz Milewski. https://www.youtube.com/playlist?list=PLbgaMIhjbmEnaH_LTkxLI7FMa2HsnawM_
-version: 0.5.5-dev
+version: 0.5.5
 author: Alexei Eleusis Díaz Vera <alexei.eleusis@gmail.com>
 homepage: https://github.com/alexeieleusis/shuttlecock
 


### PR DESCRIPTION
This prepares the classes for removal of the method from Iterable and Stream.
